### PR TITLE
Switch state set to bit_array, fix a logic bug in `match`

### DIFF
--- a/ba/bit_array.odin
+++ b/ba/bit_array.odin
@@ -1,0 +1,18 @@
+package ba
+
+import "core:container/bit_array"
+
+set_unchecked :: proc (ba: ^bit_array.Bit_Array, index: int) #no_bounds_check {
+	ba.bits[index >> 6] |= 1 << uint(index & 63)
+}
+
+get_unchecked :: proc (ba: ^bit_array.Bit_Array, index: int) -> bool #no_bounds_check {
+	return bool((ba.bits[index >> 6] >> uint(index & 63)) & 1)
+}
+
+reserve_unchecked :: proc (ba: ^bit_array.Bit_Array, size: int) {
+	if size > ba.max_index + 1 {
+		ba.max_index = size - 1
+		resize(&ba.bits, 1 + (ba.max_index >> 6))
+	}
+}


### PR DESCRIPTION
- we use custom procedures to access the bit_arrays in order to skip bounds checking, as well as assume that the bit values start at 0. this change deteriorates performance for very short regexes (<30 states) but improves it for longer ones: regex `\w+(\s+\w+){5,}` (match at least 6 space-separated words) already has 49 states, so the speedup should be worth .

- the subroutine `update_active_states` used to accept the rune as a parameter, however this is incorrect, as states that this routine is called on have already been accessed through that same rune. this caused the regex `aa` to incorrectly match the string `a`, since the state `seen first a` had a transition to state `matched aa` through the rune `a`, which was triggered again by the first `a`. the correct thing is to match on the rune `0x0` every time, effectively getting the epsilon-closure for the newly reached state.