### PR TITLE
Fix a bug that caused incorrect matches.

### DIFF
--- a/match.odin
+++ b/match.odin
@@ -9,7 +9,7 @@ match_transition :: proc(m: MatchKind, input: rune) -> bool {
 	result := false
 	switch value in m {
 	case Epsilon:
-		result = true
+		result = input == 0
 	case rune:
 		result = input == value
 	case ^Bit_Array:
@@ -47,8 +47,8 @@ match :: proc(nfa: ^NFA, input: string) -> bool {
 			if test_bit_unchecked(active_states, state) {continue}
 			ba.set(active_states, state)
 			for t in nfa.transitions[state] {
-				if test_bit_unchecked(active_states, t.to) {continue}
-				if match_transition(t.match, 0) {
+				if t.match != (Epsilon{}) { break }
+				if !test_bit_unchecked(active_states, t.to) {
 					set_bit_unchecked(active_states, t.to)
 					append(&stack, t.to)
 				}

--- a/nfa_compilation.odin
+++ b/nfa_compilation.odin
@@ -12,6 +12,7 @@ Automata :: struct {
 	end:   int,
 }
 NFA :: struct {
+	// invariant: all epsilon-transitions are at the beginning of the array.
 	transitions:   [dynamic]Transitions,
 	start:         int,
 	end:           int,
@@ -325,6 +326,9 @@ add_transition :: proc(nfa: ^NFA, from: int, to: int, match: MatchKind, group: i
 	for t in transitions {if t == transition {return}}
 	append(transitions, transition)
 
+	// maintain the invariant of having all epsilon-transitions at the beginning.
+	// it's possible to make this faster by finding the target position via binary search,
+	// but for small-ish arrays this is plenty fast.
 	for i := len(transitions) - 1; i > 0 && transitions[i-1].match != (Epsilon{}); i -= 1 {
 		transitions[i-1], transitions[i] = transitions[i], transitions[i-1]
 	}

--- a/nfa_compilation.odin
+++ b/nfa_compilation.odin
@@ -321,6 +321,11 @@ compile_charset :: proc(nfa: ^NFA, charset: Charset, start: int) -> (end: int) {
 add_transition :: proc(nfa: ^NFA, from: int, to: int, match: MatchKind, group: int = 0) {
 	TRACE(&spall_ctx, &spall_buffer, #procedure)
 	transition := Transition{to, match, group}
-	for t in nfa.transitions[from] {if t == transition {return}}
-	append(&nfa.transitions[from], transition)
+	transitions := &nfa.transitions[from]
+	for t in transitions {if t == transition {return}}
+	append(transitions, transition)
+
+	for i := len(transitions) - 1; i > 0 && transitions[i-1].match != (Epsilon{}); i -= 1 {
+		transitions[i-1], transitions[i] = transitions[i], transitions[i-1]
+	}
 }


### PR DESCRIPTION
the regex `"a?"` used to match the string `"b"` due to the `match` function incorrectly consuming the `'b'` rune in the `Epsilon` transition.

For the future, I would propose storing the `Epsilon` transitions separately from the rest, since they are conceptually different and require quite a bit of special logic.

this patch also contains a compilation pass that keeps all epsilon transitions at the beginning of the array, as well as modified logic in `match` to exploit this invariant and skip unnecessary work.